### PR TITLE
feat:  Backend job part 5

### DIFF
--- a/backend/core/serializers/trainings.py
+++ b/backend/core/serializers/trainings.py
@@ -1,0 +1,62 @@
+from rest_framework import serializers
+from core.models import Training
+
+
+class TrainingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Training
+        fields = ["id", "timestamp", "name", "description", "expiry", "type", "config"]
+
+
+class TrainingCreateSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Training
+        fields = ["name", "description", "expiry", "type", "config"]
+
+    def validate_name(self, value):
+        if Training.objects.filter(name=value).exists():
+            raise serializers.ValidationError("Training with this name already exists")
+        return value
+
+    def validate_config(self, value):
+        training_type = self.initial_data.get("type")
+
+        if training_type == "LMS":
+            # LMS type requires completance_score
+            if "completance_score" not in value:
+                raise serializers.ValidationError(
+                    "LMS training requires 'completance_score' in config"
+                )
+            if not isinstance(value["completance_score"], (int, float)):
+                raise serializers.ValidationError("completance_score must be a number")
+
+        return value
+
+
+class TrainingUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Training
+        fields = ["name", "description", "expiry", "config"]
+
+    def validate_name(self, value):
+        if (
+            self.instance
+            and Training.objects.filter(name=value).exclude(id=self.instance.id).exists()
+        ):
+            raise serializers.ValidationError("Training with this name already exists")
+        return value
+
+    def validate_config(self, value):
+        training_type = self.instance.type if self.instance else self.initial_data.get("type")
+
+        if training_type == "LMS":
+            # LMS type requires completance_score
+            if "completance_score" not in value:
+                raise serializers.ValidationError(
+                    "LMS training requires 'completance_score' in config"
+                )
+            if not isinstance(value["completance_score"], (int, float)):
+                raise serializers.ValidationError("completance_score must be a number")
+
+        return value

--- a/backend/core/views/trainings.py
+++ b/backend/core/views/trainings.py
@@ -1,6 +1,48 @@
-from rest_framework import viewsets
+from django.http import Http404
+from rest_framework import viewsets, status
+from rest_framework.response import Response
+
+from core.models import Training
+from core.serializers.trainings import (
+    TrainingSerializer,
+    TrainingCreateSerializer,
+    TrainingUpdateSerializer,
+)
+from core.permissions import ReadOnlyOrAdmin
 
 
-# ── Users ───────────────────────────────────────────────────────────────
-class TrainingViewSet(viewsets.ModelViewSet):
-    pass
+class TrainingViewSet(viewsets.GenericViewSet):
+    permission_classes = [ReadOnlyOrAdmin]
+
+    def get_object(self):
+        pk = self.kwargs.get("pk")
+        try:
+            return Training.objects.get(id=pk)
+        except Training.DoesNotExist:
+            raise Http404
+
+    # POST /trainings
+    def create(self, request):
+        serializer = TrainingCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        training = serializer.save()
+        return Response(TrainingSerializer(training).data)
+
+    # GET /trainings/{id}
+    def retrieve(self, request, pk=None):
+        training = self.get_object()
+        return Response(TrainingSerializer(training).data)
+
+    # PATCH /trainings/{id}
+    def partial_update(self, request, pk=None):
+        training = self.get_object()
+        serializer = TrainingUpdateSerializer(instance=training, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(TrainingSerializer(training).data)
+
+    # DELETE /trainings/{id}
+    def destroy(self, request, pk=None):
+        training = self.get_object()
+        training.delete()
+        return Response()


### PR DESCRIPTION
# Overview
This PR implements the basic Training CRUD operations as assigned.

## Features Implemented
- **Create Training**: `POST /api/trainings/` - Create a single training
- **Get Single Training**: `GET /api/trainings/{id}/` - Retrieve training details
- **Update Training**: `PATCH /api/trainings/{id}/` - Update training profile
- **Delete Training**: `DELETE /api/trainings/{id}/` - Remove training from system

## Technical Changes

### Files Modified:
- `backend/core/serializers/trainings.py` - Added training-specific serializers
- `backend/core/views/trainings.py` - Implemented TrainingViewSet with CRUD operations

