### PR TITLE
feat(trainings): implement Trainings page with searchable table

### DIFF
--- a/frontend/public/data/trainings.json
+++ b/frontend/public/data/trainings.json
@@ -1,0 +1,16 @@
+[
+  { "training_course": "WHS Induction", "data_source": "LMS", "upload_method": "Excel Template" },
+  { "training_course": "WHS Risk Management", "data_source": "LMS", "upload_method": "Excel Template" },
+  { "training_course": "Silica Awareness Training", "data_source": "Forms/Sharepoint", "upload_method": "Excel Template" },
+  { "training_course": "Lab Safety Course", "data_source": "TryBooking", "upload_method": "API integration" },
+  { "training_course": "Unsealed Radioisotopes course", "data_source": "TryBooking", "upload_method": "API integration" },
+  { "training_course": "Laser Safety Course", "data_source": "TryBooking", "upload_method": "API integration" },
+  { "training_course": "Snorkeler Fitness Assessment", "data_source": "TryBooking", "upload_method": "API integration" },
+  { "training_course": "Diver Assessment", "data_source": "TryBooking", "upload_method": "API integration" },
+  { "training_course": "Dive Supervisor Course", "data_source": "TryBooking", "upload_method": "API integration" },
+  { "training_course": "UWA Scientific Diver Course", "data_source": "TryBooking", "upload_method": "API integration" },
+  { "training_course": "Camms Training", "data_source": "Forms/Sharepoint", "upload_method": "Excel Template" },
+  { "training_course": "Fire Warden Training", "data_source": "Forms/Sharepoint", "upload_method": "Excel Template" },
+  { "training_course": "First Aid", "data_source": "Face to Face/External", "upload_method": "Excel Template or user input" },
+  { "training_course": "Local Area WHS Induction", "data_source": "Face to Face", "upload_method": "Excel Template or user input" }
+]

--- a/frontend/src/app/dashboard/trainings/page.tsx
+++ b/frontend/src/app/dashboard/trainings/page.tsx
@@ -1,3 +1,97 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type Training = {
+  training_course: string;
+  data_source?: string;
+  upload_method?: string;
+};
+
 export default function Trainings() {
-  return <div>Trainings</div>;
+  const [data, setData] = useState<Training[]>([]);
+  const [q, setQ] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const res = await fetch('/data/trainings.json', { cache: 'no-store' });
+        if (!res.ok) throw new Error(`Failed to load trainings: ${res.status}`);
+        const json: Training[] = await res.json();
+        if (!cancelled) setData(json);
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message ?? 'Failed to load trainings');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const term = q.trim().toLowerCase();
+    if (!term) return data;
+    return data.filter(t =>
+      (t.training_course || '').toLowerCase().includes(term) ||
+      (t.data_source || '').toLowerCase().includes(term) ||
+      (t.upload_method || '').toLowerCase().includes(term)
+    );
+  }, [q, data]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <h1 className="text-2xl font-semibold tracking-tight">Trainings</h1>
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search trainings, source, upload method..."
+          className="w-full sm:w-80 rounded-xl border px-4 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </header>
+
+      {loading && <div className="text-sm text-gray-600">Loading trainings…</div>}
+      {error && <div className="text-sm text-red-600">{error}</div>}
+
+      {!loading && !error && (
+        <div className="overflow-x-auto rounded-2xl border shadow-sm">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 text-left">
+              <tr>
+                <th className="px-4 py-3 font-medium">Training Course</th>
+                <th className="px-4 py-3 font-medium">Data Source</th>
+                <th className="px-4 py-3 font-medium">Upload Method</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((t, i) => (
+                <tr key={`${t.training_course}-${i}`} className={i % 2 ? 'bg-white' : 'bg-gray-50/50'}>
+                  <td className="px-4 py-3 font-medium">{t.training_course}</td>
+                  <td className="px-4 py-3"><Badge>{t.data_source || '—'}</Badge></td>
+                  <td className="px-4 py-3">{t.upload_method || '—'}</td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td className="px-4 py-6 text-gray-500" colSpan={3}>No trainings match your search.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Badge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium">
+      {children}
+    </span>
+  );
 }


### PR DESCRIPTION
# Summary

Implements the new Trainings page in the dashboard.  
This includes UI, static dataset, and navigation link.

---

## Changes

### Trainings Page UI (`/dashboard/trainings`)
- Added `page.tsx` that fetches and renders a table of trainings.
- Includes search box for filtering by course, data source, or upload method.
- Handles loading and error states gracefully.

### Dataset
- Added `public/data/trainings.json` sourced from the provided Excel sheet.
- Contains initial list of 14 training programs with their data source and upload method.
- Used as the data source for the Trainings page (to be swapped to backend API later).

### Navigation
- Sidebar already contained a “Training Programs” link pointing to `/dashboard/trainings`.
- Verified and committed this to ensure consistency.

---

## How to Test (Frontend)

1. Run the frontend:
   ```bash
   cd frontend
   npm run dev

Open http://localhost:3000/dashboard/trainings

Verify:

- Trainings table displays all rows from trainings.json.

- Search box filters correctly.

- Sidebar → “Training Programs” navigates to the page.

## Backend Changes
## LMS Upload Support
## What’s New

- Added upload_lms action to TrainingViewSet.

- New endpoint:
```POST /api/trainings/{id}/upload-lms/

## Features

- Accepts Excel file (file in form-data).

- Parses LMS completion records.

- Matches users by username.

- Updates or creates TrainingRecords.

- Marks completion if score ≥ config.completance_score.

## How to Test (Backend)

1. Start backend server:

``` bash
cd backend
python manage.py runserver

2. Find a training ID:

```bash
curl http://localhost:8000/api/trainings/

3. Upload LMS Excel file:

```bash
curl -X POST \
  -F "file=@lms_upload.xlsx" \
  http://localhost:8000/api/trainings/<training-id>/upload-lms/

4. Expected response:

```json
{
  "message": "LMS upload processed",
  "created": 5,
  "updated": 2
}
