### PR TITLE
feat(Training): Training management system frontend

### DIFF
--- a/frontend/src/api/trainings.ts
+++ b/frontend/src/api/trainings.ts
@@ -1,4 +1,5 @@
 import * as api from "@/api/common";
+import { swr } from "@/api/common";
 
 export interface Training {
   id: string;
@@ -34,7 +35,15 @@ export interface ListTrainingResponse {
 }
 
 // API functions
-export async function listTrainings(params?: {
+export function listTrainings() {
+  let { data, error, isLoading } = swr<Training[]>("/api/trainings");
+  if (!data || error || isLoading) {
+    data = [];
+  }
+  return { data, error, isLoading };
+}
+
+export async function listTrainingsWithParams(params?: {
   search?: string;
   type?: string;
   page?: number;

--- a/frontend/src/app/dashboard/trainings/create_dialog.tsx
+++ b/frontend/src/app/dashboard/trainings/create_dialog.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { revalidatePath } from "@/api/common";
+import { TrainingCreateRequest, createTraining } from "@/api/trainings";
+import SubmitButton from "@/components/common/submit";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useForm } from "@/hooks/form";
+
+export function CreateTrainingDialog({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  const { useField, error, working, reset, submit } = useForm();
+  const [name, setName] = useField("");
+  const [description, setDescription] = useField("");
+  const [type, setType] = useField<"LMS" | "TRYBOOKING" | "EXTERNAL">("LMS");
+  const [expiry, setExpiry] = useField("");
+  const [completanceScore, setCompletanceScore] = useField("");
+
+  const handleCreate = submit(async () => {
+    const config: Record<string, any> = {};
+
+    // LMS type requires completance_score
+    if (type === "LMS") {
+      config.completance_score = parseInt(completanceScore) || 0;
+    }
+
+    const data: TrainingCreateRequest = {
+      name,
+      description,
+      type,
+      expiry: parseInt(expiry) || 0,
+      config,
+    };
+
+    await createTraining(data);
+    revalidatePath("/api/trainings");
+    reset();
+    setOpen(false);
+    toast.success("Training Created");
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        setOpen(newOpen);
+        if (!newOpen) {
+          reset();
+        }
+      }}
+    >
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create Training</DialogTitle>
+          <DialogDescription>Create a new training course by specifying its details.</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Name</label>
+            <Input placeholder="e.g. Laboratory Safety Training" value={name} onValueChange={setName} />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Description</label>
+            <Input
+              placeholder="e.g. Basic laboratory safety procedures for students"
+              value={description}
+              onValueChange={setDescription}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Type</label>
+            <Select value={type} onValueChange={(value: "LMS" | "TRYBOOKING" | "EXTERNAL") => setType(value)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select training type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="LMS">LMS</SelectItem>
+                <SelectItem value="TRYBOOKING">TryBooking</SelectItem>
+                <SelectItem value="EXTERNAL">External</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Expiry (days)</label>
+            <Input type="number" placeholder="0 for no expiry" value={expiry} onValueChange={setExpiry} min="0" />
+            <p className="text-muted-foreground text-xs">Number of days after which training expires (0 = no expiry)</p>
+          </div>
+
+          {type === "LMS" && (
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">Completion Score</label>
+              <Input
+                type="number"
+                placeholder="90"
+                value={completanceScore}
+                onValueChange={setCompletanceScore}
+                min="0"
+              />
+              <p className="text-muted-foreground text-xs">Minimum score required to complete the training</p>
+            </div>
+          )}
+
+          <div className="text-destructive text-sm empty:hidden">{error}</div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <SubmitButton disabled={working} onClick={handleCreate}>
+            Create
+          </SubmitButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/dashboard/trainings/delete_button.tsx
+++ b/frontend/src/app/dashboard/trainings/delete_button.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { revalidatePath } from "@/api/common";
+import { deleteTraining } from "@/api/trainings";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+export default function DeleteTrainingButton({ id, name }: { id: string; name: string }) {
+  const [open, setOpen] = useState(false);
+  const [working, setWorking] = useState(false);
+
+  const handleDelete = async () => {
+    setWorking(true);
+    try {
+      await deleteTraining(id);
+      revalidatePath("/api/trainings");
+      setOpen(false);
+      toast.success("Training Deleted");
+    } catch (error: any) {
+      toast.error(error.message || "Failed to delete training");
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="destructive">
+          Delete
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Training</DialogTitle>
+          <DialogDescription>Are you sure you want to delete "{name}"? This action cannot be undone.</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <Button variant="destructive" disabled={working} onClick={handleDelete}>
+            {working ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/dashboard/trainings/update_dialog.tsx
+++ b/frontend/src/app/dashboard/trainings/update_dialog.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { revalidatePath } from "@/api/common";
+import { Training, TrainingUpdateRequest, updateTraining } from "@/api/trainings";
+import SubmitButton from "@/components/common/submit";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useForm } from "@/hooks/form";
+
+export function UpdateTrainingDialog({ training, children }: { training: Training; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  const { useField, error, working, submit } = useForm();
+  const [name, setName] = useField(training.name);
+  const [description, setDescription] = useField(training.description);
+  const [type, setType] = useField<"LMS" | "TRYBOOKING" | "EXTERNAL">(training.type);
+  const [expiry, setExpiry] = useField(training.expiry.toString());
+  const [completanceScore, setCompletanceScore] = useField(training.config?.completance_score?.toString() || "");
+
+  const handleUpdate = submit(async () => {
+    const config: Record<string, any> = { ...training.config };
+
+    // LMS type requires completance_score
+    if (type === "LMS") {
+      config.completance_score = parseInt(completanceScore) || 0;
+    } else {
+      // Remove completance_score if not LMS type
+      delete config.completance_score;
+    }
+
+    const data: TrainingUpdateRequest = {
+      name,
+      description,
+      expiry: parseInt(expiry) || 0,
+      config,
+    };
+
+    await updateTraining(training.id, data);
+    revalidatePath("/api/trainings");
+    setOpen(false);
+    toast.success("Training Updated");
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Update Training</DialogTitle>
+          <DialogDescription>Update the training course details.</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Name</label>
+            <Input placeholder="e.g. Laboratory Safety Training" value={name} onValueChange={setName} />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Description</label>
+            <Input
+              placeholder="e.g. Basic laboratory safety procedures for students"
+              value={description}
+              onValueChange={setDescription}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Type</label>
+            <Select value={type} onValueChange={(value: "LMS" | "TRYBOOKING" | "EXTERNAL") => setType(value)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select training type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="LMS">LMS</SelectItem>
+                <SelectItem value="TRYBOOKING">TryBooking</SelectItem>
+                <SelectItem value="EXTERNAL">External</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium">Expiry (days)</label>
+            <Input type="number" placeholder="0 for no expiry" value={expiry} onValueChange={setExpiry} min="0" />
+            <p className="text-muted-foreground text-xs">Number of days after which training expires (0 = no expiry)</p>
+          </div>
+
+          {type === "LMS" && (
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium">Completion Score</label>
+              <Input
+                type="number"
+                placeholder="90"
+                value={completanceScore}
+                onValueChange={setCompletanceScore}
+                min="0"
+              />
+              <p className="text-muted-foreground text-xs">Minimum score required to complete the training</p>
+            </div>
+          )}
+
+          <div className="text-destructive text-sm empty:hidden">{error}</div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost">Cancel</Button>
+          </DialogClose>
+          <SubmitButton disabled={working} onClick={handleUpdate}>
+            Update
+          </SubmitButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
This PR implements training management CRUD with pagination, sorting, and filtering in frontend.

Training Management Page: ```frontend/src/app/dashboard/trainings/page.tsx``` - Main page with table, search, filters, and pagination

Create Training Dialog: ```frontend/src/app/dashboard/trainings/create_dialog.tsx``` - Create training with type-specific configuration
Update Training Dialog: ```frontend/src/app/dashboard/trainings/update_dialog.tsx```- Update training details
Delete Training Button: ```frontend/src/app/dashboard/trainings/delete_button.tsx``` - Delete training

Also, ```frontend/src/api/trainings.ts```: Added SWR integration for data fetching