### PR TITLE
API: paginate Training Records list (page/page_size; max_page_size=100)

### DIFF
--- a/backend/core/views/training_records.py
+++ b/backend/core/views/training_records.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 from django.utils.dateparse import parse_date
 from rest_framework import serializers, viewsets
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.pagination import PageNumberPagination  # <-- added
 
 from ..models import TrainingRecord, Training, User
 from ..permissions import IsAdmin  # same permission you use elsewhere
@@ -41,13 +42,22 @@ class TrainingRecordPatchSerializer(serializers.Serializer):
         return instance
 
 
+# --------- Pagination (per-view) ---------
+class TrainingRecordPage(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
 # --------- ViewSet ---------
 class TrainingRecordViewSet(viewsets.ModelViewSet):
     """
     CRUD for per-user training completions.
     Query params: user, training, expired=true|false, before=YYYY-MM-DD, after=YYYY-MM-DD, order_by=timestamp|-timestamp
+    Pagination: page, page_size (max 100)
     """
 
+    pagination_class = TrainingRecordPage  # <-- added
     queryset = TrainingRecord.objects.select_related("user", "training").order_by("-timestamp")
     permission_classes = [IsAuthenticated, IsAdmin]
     http_method_names = ["get", "post", "patch", "delete", "head", "options"]


### PR DESCRIPTION
Summary
Add page-number pagination to GET /api/training-records. Default page size 20; supports ?page and ?page_size (max 100).

What changed

backend/core/views/training_records.py:

Added TrainingRecordPage (PageNumberPagination).

Set pagination_class = TrainingRecordPage on TrainingRecordViewSet.

New behavior

GET /api/training-records?page=1&page_size=20 returns:

{ "count": <int>, "next": "<url|null>", "previous": "<url|null>", "results": [ ... ] }


Other endpoints unchanged. No settings or model changes.

Compatibility note

Response shape for this list endpoint changed from raw array to paginated envelope (results). Clients should read from results.

Testing

Created 2 records; verified:

page=1&page_size=1 → count=2, next populated, 1 item in results.

page=2&page_size=1 → previous populated, final item shown.