### PR TITLE
feat(groups): expose trainings on UserGroupSerializer

### DIFF
--- a/backend/core/serializers/groups.py
+++ b/backend/core/serializers/groups.py
@@ -6,10 +6,14 @@ class UserGroupSerializer(serializers.ModelSerializer):
     users = serializers.PrimaryKeyRelatedField(
         queryset=User.objects.all(), many=True, required=False
     )
+    # NEW: expose trainings attached to this group
+    trainings = serializers.PrimaryKeyRelatedField(
+        queryset=Training.objects.all(), many=True, required=False
+    )
 
     class Meta:
         model = UserGroup
-        fields = ["id", "name", "description", "users", "timestamp"]
+        fields = ["id", "name", "description", "users", "trainings", "timestamp"]
         read_only_fields = ["id", "timestamp"]
 
 


### PR DESCRIPTION
Summary
- Adds `trainings` as a PrimaryKeyRelatedField on UserGroupSerializer.
- Extends Meta.fields to include "trainings".

Why
- Enables backend support for "list all trainings for a specific group" and UI to view/update linked trainings.

Scope
- backend/core/serializers/groups.py only.
- No DB migrations, additive only.

Testing
- GET /api/groups/<id>/ now includes "trainings": [<training ids>].
